### PR TITLE
adding new command to display weapon info

### DIFF
--- a/commands/index.ts
+++ b/commands/index.ts
@@ -1,5 +1,7 @@
 import * as ping from "./utility/ping";
+import * as weapon from "./slash/weapon";
 
 export const commands = {
   ping,
+  weapon
 };

--- a/commands/slash/weapons.ts
+++ b/commands/slash/weapons.ts
@@ -1,0 +1,31 @@
+import { CommandInteraction, SlashCommandBuilder } from "discord.js";
+
+import data from "@massif/lancer-data";
+
+const weaponDescription = [];
+
+data?.weapons?.forEach((item) => {
+    weaponDescription.push({ name: item.name, value: item.description || "No description of this weapon was found." })
+});
+
+console.log(...weaponDescription)
+
+export const command = new SlashCommandBuilder()
+    .setName("weapon")
+    .setDescription("Displays information about all weapons.")
+    .addStringOption(option =>
+        option.setName('name')
+            .setDescription('Information pertaining to the weapon selected.')
+            .setRequired(true)
+            .addChoices(
+                { name: 'Anti-Materiel Rifle', value: 'Anti-Materiel Rifle' },
+                { name: 'Assault Rifle', value: 'Assault Rifle' },
+                { name: 'Charged Blade', value: 'Charged Blade' },
+            ));
+
+export async function execute(interaction: CommandInteraction) {
+    const selectedWeaponDescription = interaction.options.getString('name');
+
+    return interaction.reply(selectedWeaponDescription);
+}
+


### PR DESCRIPTION
## Type of change

This incoming change will add a discord slash command called `/weapon` .

## What's the purpose of the PR?

This change will allow users to get information about various guns in the Lancer TTRPG. 

## What's the impact of the change?

The user will have the ability to get info related to weapons in the game. 
